### PR TITLE
Switched from localhost IP to localhost name

### DIFF
--- a/all.yml
+++ b/all.yml
@@ -1,6 +1,6 @@
 ---
 
-- hosts: 127.0.0.1
+- hosts: localhost
   connection: local
   tasks:
     - name: create ssh directory


### PR DESCRIPTION
While using Ansible 2.1.1.0, I ran into problems when using `127.0.0.1` as the host:

`PLAY [127.0.0.1] ***************************************************************`
`skipping: no hosts matched`

This appears to be caused by Ansible not setting up `/etc/ansible/hosts`. I think Ansible is trying to treat `127.0.0.1` as a hostname instead of an IP address, and when it can't resolve the name in the Ansible hosts, it skips. 

When I use the name `localhost` instead, everything works properly.
